### PR TITLE
mkcertの自動化+RootlessDocker対応の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,17 @@
 ## Requirement
-- [mkcert](https://github.com/FiloSottile/mkcert)
+- [Docker](https://www.docker.com/)
 - [Misskey (master)](https://github.com/misskey-dev/misskey)
 
 ### How to Run
 1. Create directories.
-    - `mkdir /cert`
-    - `mkdir /cert/nginx`
-    - `mkdir /cert/root`
-2. Run `mkcert -install`
-3. Copy `rootCA.pem` to `/cert/root`
-    - The location of `rootCA.pem` can be seen with `mkcert -CAROOT`.
-4. Run `mkcert -cert-file certs/nginx/misskey.crt -key-file certs/nginx/misskey.key misskey.localhost`
-5. Clone Misskey
+    - `mkdir -p /certs/nginx`
+    - `mkdir -p /certs/root`
+2. Run `./gencert.sh`
+3. Clone Misskey
     - `git clone -b master https://github.com/misskey-dev/misskey.git`
-6. Setup container
+4. Setup container
     - `docker compose build`
     - `docker compose run --rm misskey pnpm run init`
-7. Start container
+5. Start container
     - `docker compose up -d`
+6. Access to `https://misskey.local:4430` in your browser.

--- a/README.md
+++ b/README.md
@@ -3,15 +3,12 @@
 - [Misskey (master)](https://github.com/misskey-dev/misskey)
 
 ### How to Run
-1. Create directories.
-    - `mkdir -p /certs/nginx`
-    - `mkdir -p /certs/root`
-2. Run `./gencert.sh`
-3. Clone Misskey
+1. Run `./gencert.sh`
+2. Clone Misskey
     - `git clone -b master https://github.com/misskey-dev/misskey.git`
-4. Setup container
+3. Setup container
     - `docker compose build`
     - `docker compose run --rm misskey pnpm run init`
-5. Start container
+4. Start container
     - `docker compose up -d`
-6. Access to `https://misskey.local:4430` in your browser.
+5. Access to `https://misskey.local:4430` in your browser.

--- a/compose.yml
+++ b/compose.yml
@@ -6,8 +6,8 @@ services:
       - ./configs/misskey/nginx/confs:/etc/nginx/confs
       - ./certs/nginx:/etc/nginx/certs
     ports:
-      - 80:80
-      - 443:443
+      - 8080:80
+      - 4430:443
     extra_hosts:
       - host.docker.internal:host-gateway
   misskey:

--- a/gencert.sh
+++ b/gencert.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# Create the certs directory
+mkdir -p ./certs/root
+mkdir -p ./certs/nginx
+
 # Build the gencert image and run it
 docker build ./gencert/. -t shuttlepub/gencert:latest
 docker run --mount "type=bind,source=./certs,target=/certs" -it shuttlepub/gencert:latest

--- a/gencert.sh
+++ b/gencert.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# Build the gencert image and run it
+docker build ./gencert/. -t shuttlepub/gencert:latest
+docker run --mount "type=bind,source=./certs,target=/certs" -it shuttlepub/gencert:latest

--- a/gencert/Dockerfile
+++ b/gencert/Dockerfile
@@ -1,0 +1,13 @@
+FROM docker.io/ubuntu:24.04
+
+RUN apt update -q \
+	&& apt install -yq \
+	mkcert \
+	&& apt clean \
+	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ADD mkcert.sh /mkcert.sh
+
+RUN mkcert --install
+
+CMD [ "/mkcert.sh" ]

--- a/gencert/mkcert.sh
+++ b/gencert/mkcert.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+cp /root/.local/share/mkcert/rootCA.pem /certs/root/
+mkcert -cert-file /certs/nginx/misskey.crt -key-file /certs/nginx/misskey.key misskey.localhost


### PR DESCRIPTION
タイトルの通りです。mkcertをdocker内で全て完結するようにし、Rootless環境で怒られる80と443ポートのバインドを別ポートに変更しました

初回接続時にブラウザから警告が表示されるようになりますが、chromium系なら`--ignore-certificate-errors`を付けて起動することで回避可能なのでこれかPlaywrightとか使うにしても問題にはならないと思います。
参考: https://zenn.dev/idumist/scraps/515fad317f7a4b
